### PR TITLE
[fix] locale and theme plugins fails when storage is defined

### DIFF
--- a/sources/plugins/Locale.ts
+++ b/sources/plugins/Locale.ts
@@ -6,7 +6,7 @@ declare function require(name:string):any;
 export function Locale(app: IJetApp, view: IJetView, config: any){
 	config = config || {};
 	const storage = config.storage;
-	let lang = storage ? storage.get("lang") : ( config.lang || "en" );
+	let lang = storage ? ( storage.get("lang") || "en" ) : ( config.lang || "en" );
 
 
 	const service = {

--- a/sources/plugins/Theme.ts
+++ b/sources/plugins/Theme.ts
@@ -3,7 +3,7 @@ import {IJetApp, IJetURL, IJetView} from "../interfaces";
 export function Theme(app: IJetApp, view: IJetView, config: any){
 	config = config || {};
 	const storage = config.storage;
-	let theme = storage ? storage.get("theme") : (config.theme || "flat-default");
+	let theme = storage ? (storage.get("theme")||"flat-default") : (config.theme || "flat-default");
 
 	const service = {
 		getTheme(){ return theme; },


### PR DESCRIPTION
Impossible to use app.use(plugins.Locale, {storage:webix.storage.local}); as initially there's no value in storage.