### PR TITLE
Regexp copy gives wrong result

### DIFF
--- a/sources/JetApp.ts
+++ b/sources/JetApp.ts
@@ -80,7 +80,7 @@ export class JetApp extends JetBase implements IJetApp {
 			}
 
 			if (point && typeof point === "object" &&
-				!(point instanceof webix.DataCollection)) {
+				!(point instanceof webix.DataCollection) && !(point instanceof RegExp)) {
 				if (point instanceof Date) {
 					target[method] = new Date(point);
 				} else {


### PR DESCRIPTION
https://docs.webix.com/desktop__formatted_text_inputs.html

copyConfig on regexp results wrong behaviour. Assigning the regexp pattern fixes the bug. Other solution is to impelement a copy function for regexp. But I think there is no need for it.