### PR TITLE
[update] order of destroy and init events

### DIFF
--- a/dist/JetApp.js
+++ b/dist/JetApp.js
@@ -284,10 +284,6 @@ var JetApp = (function (_super) {
                 _this._view = view;
                 // render url state for the root
                 return view.render(_this._container, parsed, _this._parent).then(function (root) {
-                    // destroy and detack old view
-                    if (oldview && oldview !== _this._view) {
-                        oldview.destructor();
-                    }
                     if (_this._view.getRoot().getParentView()) {
                         _this._container = root;
                     }

--- a/dist/JetView.js
+++ b/dist/JetView.js
@@ -186,7 +186,12 @@ var JetView = (function (_super) {
                     result.ui.id = prev.config.id;
                 }
             }
+            var oldScope = this._container.$scope;
             this._root = this.app.webix.ui(result.ui, this._container);
+            // check, if some other view need to be destroyed
+            if (oldScope && oldScope !== this && oldScope.getRoot && oldScope.getRoot().$destructed) {
+                oldScope.destructor();
+            }
             if (this._root.getParentView()) {
                 this._container = this._root;
             }
@@ -255,10 +260,6 @@ var JetView = (function (_super) {
     JetView.prototype._renderSubView = function (sub, view, suburl) {
         var cell = this.app.webix.$$(sub.id);
         return view.render(cell, suburl, this).then(function (ui) {
-            // destroy old view
-            if (sub.view && sub.view !== view) {
-                sub.view.destructor();
-            }
             // save info about a new view
             sub.view = view;
             sub.id = ui.config.id;

--- a/dist/JetView.js
+++ b/dist/JetView.js
@@ -190,7 +190,12 @@ var JetView = (function (_super) {
             this._root = this.app.webix.ui(result.ui, this._container);
             // check, if some other view need to be destroyed
             if (oldScope && oldScope !== this && oldScope.getRoot && oldScope.getRoot().$destructed) {
-                oldScope.destructor();
+                if (oldScope.app !== this.app && oldScope.app.getRoot().$destructed) {
+                    oldScope.app.destructor();
+                }
+                else {
+                    oldScope.destructor();
+                }
             }
             if (this._root.getParentView()) {
                 this._container = this._root;

--- a/sources/JetApp.ts
+++ b/sources/JetApp.ts
@@ -316,11 +316,6 @@ export class JetApp extends JetBase implements IJetApp {
 
 				// render url state for the root
 				return view.render(this._container, parsed, this._parent).then(root => {
-
-					// destroy and detack old view
-					if (oldview && oldview !== this._view) {
-						oldview.destructor();
-					}
 					if (this._view.getRoot().getParentView()){
 						this._container = root;
 					}

--- a/sources/JetView.ts
+++ b/sources/JetView.ts
@@ -207,7 +207,13 @@ export class JetView extends JetBase{
 				}
 			}
 
+			const oldScope = (this._container as any).$scope;
 			this._root = this.app.webix.ui(result.ui, this._container);
+			// check, if some other view need to be destroyed
+			if (oldScope && oldScope !== this && oldScope.getRoot && oldScope.getRoot().$destructed){
+				oldScope.destructor();
+			}
+
 			if (this._root.getParentView()){
 				this._container = this._root;
 			}
@@ -286,11 +292,6 @@ export class JetView extends JetBase{
 					suburl:IJetURL):Promise<webix.ui.baseview>{
 		const cell = this.app.webix.$$(sub.id);
 		return view.render(cell, suburl, this).then(ui => {
-			// destroy old view
-			if (sub.view && sub.view !== view){
-				sub.view.destructor();
-			}
-
 			// save info about a new view
 			sub.view = view;
 			sub.id = ui.config.id as string;

--- a/sources/JetView.ts
+++ b/sources/JetView.ts
@@ -211,7 +211,11 @@ export class JetView extends JetBase{
 			this._root = this.app.webix.ui(result.ui, this._container);
 			// check, if some other view need to be destroyed
 			if (oldScope && oldScope !== this && oldScope.getRoot && oldScope.getRoot().$destructed){
-				oldScope.destructor();
+				if (oldScope.app !== this.app && oldScope.app.getRoot().$destructed){
+					oldScope.app.destructor();
+				} else {
+					oldScope.destructor();
+				}
 			}
 
 			if (this._root.getParentView()){


### PR DESCRIPTION
Update changes the order of events.
Now, when view A replaces view B, events will go like next

- B.destroy()
- A.init()

To do so, we remove direct destructor() calls from the rendering callback
and place the same call just after rendering new UI
( after this point we don't need old view anymore )