### PR TITLE
[fix] view.refresh doesn't work for views with sub-elements

### DIFF
--- a/dist/JetApp.js
+++ b/dist/JetApp.js
@@ -96,11 +96,7 @@ var JetApp = (function (_super) {
         }
     };
     JetApp.prototype.refresh = function () {
-        var temp = this._container;
-        //enforce view recreation
-        this._view._name = webix.uid() + "";
-        this._container = null;
-        this.render(temp, parse(this.getRouter().get()), this._parent);
+        this._view.refresh();
     };
     JetApp.prototype.loadView = function (url) {
         var _this = this;

--- a/dist/JetBase.d.ts
+++ b/dist/JetBase.d.ts
@@ -37,5 +37,6 @@ export declare abstract class JetBase implements IJetView {
     abstract show(path: any, config?: any): any;
     protected abstract _render(url: IJetURL): Promise<any>;
     protected abstract _urlChange(url: IJetURL): Promise<any>;
+    protected _destroySubs(): void;
     protected _init_url_data(url: IJetURL): void;
 }

--- a/dist/JetBase.js
+++ b/dist/JetBase.js
@@ -14,15 +14,7 @@ var JetBase = (function () {
         for (var i = events.length - 1; i >= 0; i--) {
             events[i].obj.detachEvent(events[i].id);
         }
-        // destroy sub views
-        for (var key in this._subs) {
-            var subView = this._subs[key].view;
-            // it possible that subview was not loaded with any content yet
-            // so check on null
-            if (subView) {
-                subView.destructor();
-            }
-        }
+        this._destroySubs();
         this._events = this._container = this.app = this._parent = null;
     };
     JetBase.prototype.setParam = function (id, value, url) {
@@ -119,6 +111,19 @@ var JetBase = (function () {
     };
     JetBase.prototype.getName = function () {
         return this._name;
+    };
+    JetBase.prototype._destroySubs = function () {
+        // destroy sub views
+        for (var key in this._subs) {
+            var subView = this._subs[key].view;
+            // it possible that subview was not loaded with any content yet
+            // so check on null
+            if (subView) {
+                subView.destructor();
+            }
+        }
+        //reset to prevent memory leaks
+        this._subs = {};
     };
     JetBase.prototype._init_url_data = function (url) {
         if (url && url[0]) {

--- a/dist/JetView.js
+++ b/dist/JetView.js
@@ -153,11 +153,15 @@ var JetView = (function (_super) {
     JetView.prototype.refresh = function () {
         var _this = this;
         this._destroyKids();
+        this._destroySubs();
+        if (this._container.tagName)
+            this._root.destructor();
         var url = [];
-        if (this._index > 1)
+        if (this._index)
             url = parse(this.app.getRouter().get()).slice(this._index - 1);
         this._render(url).then(function () {
-            _this._parentFrame.id = _this.getRoot().config.id;
+            if (_this._parentFrame)
+                _this._parentFrame.id = _this.getRoot().config.id;
         });
     };
     JetView.prototype._render = function (url) {

--- a/dist/interfaces.d.ts
+++ b/dist/interfaces.d.ts
@@ -36,7 +36,6 @@ export interface IJetURLChunk {
 export declare type IJetURL = IJetURLChunk[];
 export interface IJetView {
     app: IJetApp;
-    _name: string;
     $$(name: string): webix.ui.baseview;
     contains(view: IJetView): boolean;
     getName(): string;

--- a/sources/JetApp.ts
+++ b/sources/JetApp.ts
@@ -118,11 +118,7 @@ export class JetApp extends JetBase implements IJetApp {
 	}
 
 	refresh(){
-		const temp = this._container;
-		//enforce view recreation
-		this._view._name = webix.uid()+"";
-		this._container = null;
-		this.render(temp, parse(this.getRouter().get()), this._parent);
+		this._view.refresh();
 	}
 
 	loadView(url): Promise<any> {

--- a/sources/JetBase.ts
+++ b/sources/JetBase.ts
@@ -36,16 +36,7 @@ export abstract class JetBase implements IJetView{
 			events[i].obj.detachEvent(events[i].id);
 		}
 
-		// destroy sub views
-		for (const key in this._subs){
-			const subView = this._subs[key].view;
-			// it possible that subview was not loaded with any content yet
-			// so check on null
-			if (subView){
-				subView.destructor();
-			}
-		}
-
+		this._destroySubs();
 		this._events = this._container = this.app = this._parent = null;
 	}
 	setParam(id:string, value:any, url?:boolean){
@@ -162,6 +153,21 @@ export abstract class JetBase implements IJetView{
 	public abstract show(path:any, config?:any);
 	protected abstract _render(url: IJetURL) : Promise<any>;
 	protected abstract _urlChange(url: IJetURL) : Promise<any>;
+
+	protected _destroySubs(){
+		// destroy sub views
+		for (const key in this._subs){
+			const subView = this._subs[key].view;
+			// it possible that subview was not loaded with any content yet
+			// so check on null
+			if (subView){
+				subView.destructor();
+			}
+		}
+
+		//reset to prevent memory leaks
+		this._subs = {};
+	}
 	protected _init_url_data(url:IJetURL){
 		if (url && url[0]){
 			this._data = {};

--- a/sources/JetView.ts
+++ b/sources/JetView.ts
@@ -171,11 +171,16 @@ export class JetView extends JetBase{
 
 	refresh(){
 		this._destroyKids();
+		this._destroySubs();
+		if ((this._container as any).tagName)
+			this._root.destructor();
+
 		let url = [];
-		if (this._index > 1)
+		if (this._index)
 			url = parse(this.app.getRouter().get()).slice(this._index-1);
 		this._render(url).then(() => {
-			this._parentFrame.id = this.getRoot().config.id as string;
+			if (this._parentFrame)
+				this._parentFrame.id = this.getRoot().config.id as string;
 		});
 	}
 

--- a/sources/interfaces.ts
+++ b/sources/interfaces.ts
@@ -41,7 +41,6 @@ export type IJetURL = IJetURLChunk[];
 
 export interface IJetView{
 	app: IJetApp;
-	_name: string;
 	$$(name:string):webix.ui.baseview;
 	contains(view: IJetView):boolean;
 	getName():string;


### PR DESCRIPTION
There were 2 major issues in the previous solution

a)
rendering url was not calculated for top level views
it was expected that for top level views user will call app.refresh
but real usage is different

b)
The subviews were not destroyed but recreated during refresh.
As result old subviews were keeped in memory and complex side-effects were possible.

As part of update app.refresh logic changed as well, not it triggers refresh
of the top view, instead of using its own custom logic.