### PR TITLE
[fix] ability to use map of overrides in view config

### DIFF
--- a/sources/JetAppBase.ts
+++ b/sources/JetAppBase.ts
@@ -86,7 +86,7 @@ export class JetAppBase extends JetBase implements IJetView {
 			}
 
 			if (point && typeof point === "object" &&
-				!(point instanceof this.webix.DataCollection) && !(point instanceof RegExp)) {
+				!(point instanceof this.webix.DataCollection) && !(point instanceof RegExp) && !(point instanceof Map)) {
 				if (point instanceof Date) {
 					target[method] = new Date(point);
 				} else {


### PR DESCRIPTION
File Manager uses Map in view config while JetView.copyConfig corrupts it