### PR TITLE
[fix] correct type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/jet.mjs",
-      "require": "./dist/jet.umd.js"
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/jet.mjs"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/jet.umd.js"
+      }
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
fixes the following error which occurs when working with Jet in a project using TS:

> There are types at '.../node_modules/webix-jet/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'webix-jet' library may need to update its package.json or typings.ts(7016)