### PR TITLE
[fix] UnloadGuard: do not address non-existing subviews

### DIFF
--- a/sources/JetBase.ts
+++ b/sources/JetBase.ts
@@ -90,7 +90,7 @@ export abstract class JetBase implements IJetView{
 	contains(view: IJetView){
 		for (const key in this._subs){
 			const kid = this._subs[key].view;
-			if (kid === view || kid.contains(view)){
+			if (kid && (kid === view || kid.contains(view))){
 				return true;
 			}
 		}


### PR DESCRIPTION
https://snippet.webix.com/gkxtog6s
Also can be tested locally on Jet 3.0.1

`kid` in this line can be `undefined` if a nested subview wasn't loaded
https://github.com/webix-hub/webix-jet/blob/15a554f2c49653956211f7a0137c5814f6bb7938/sources/JetBase.ts#L92