### PR TITLE
[fix] hide subviews designated as popups when inactive

### DIFF
--- a/sources/JetView.ts
+++ b/sources/JetView.ts
@@ -223,6 +223,10 @@ export class JetView extends JetBase{
 			current.view.destructor();
 		}
 
+		if (slot && slot.popup) {
+            result.ui.hidden = true;
+        }
+
 		try {
 			// special handling for adding inside of multiview - preserve old id
 			if (slot && !show){


### PR DESCRIPTION
Use case:

https://snippet.webix.com/w3fumlil (simulating mobile env) -> scroll down, you will see some empty space below the main editor area. Basically, we have a redundant spacer inserted into the body, just below the actual view.

Issue: dynamic subview is designated as a popup, but that subview is not visible yet. Still, it is inserted into the body, and in some cases (`env.mobile`/`fullScreen`) we will be able to see this placeholder (like in the example above). In this case, the subview is used as a slot for the image editor.

This issue also potentially affects other Jet-based widgets where a similar approach is used (I was able to reproduce it in Gantt, and there may be some other cases as well).

With this fix: https://snippet.webix.com/btt79guw.

Somehow, I wasn't able to reproduce this issue through unit tests only (at least using the existing setup/environment from this repo), so I did not include any with this PR.