### PR TITLE
[fix] uncaught null when jet view destroyed mid-render

### DIFF
--- a/sources/JetAppBase.ts
+++ b/sources/JetAppBase.ts
@@ -147,7 +147,9 @@ export class JetAppBase extends JetBase implements IJetView {
 		}
 
 		return this.getSubView().refresh().then(view => {
-			this.callEvent("app:route", [this.getUrl()]);
+			if (this._container){
+				this.callEvent("app:route", [this.getUrl()]);
+			}
 			return view;
 		});
 	}
@@ -362,12 +364,17 @@ export class JetAppBase extends JetBase implements IJetView {
 			.then(() => this.createFromURL(segment.current()))
 			.then(view => view.render(root, segment))
 			.then(base => {
-				this.$router.set(segment.route.path, { silent:true });
-				this.callEvent("app:route", [this.getUrl()]);
+				// app may have been destroyed while the view was rendering
+				if (this._container){
+					this.$router.set(segment.route.path, { silent:true });
+					this.callEvent("app:route", [this.getUrl()]);
+				}
 				return base;
 			});
 
-		this.ready = this.ready.then(() => ready);
+		this.ready = this.ready.then(() => ready).catch(e => {
+			if (!(e instanceof NavigationBlocked)) throw e;
+		});
 		return ready;
 	}
 

--- a/sources/JetAppBase.ts
+++ b/sources/JetAppBase.ts
@@ -375,9 +375,14 @@ export class JetAppBase extends JetBase implements IJetView {
 				return base;
 			});
 
-		this.ready = this.ready.then(() => ready).catch(e => {
+		// swallow benign navigation aborts on THIS render's promise directly, so an
+		// overlapping/blocked navigation can never leak an unhandled rejection while an
+		// earlier render is still parked (real errors are rethrown so they stay observable)
+		const settled = ready.catch(e => {
 			if (!(e instanceof NavigationBlocked)) throw e;
 		});
+		// keep the public ready promise progressing across renders (never sticks on abort)
+		this.ready = this.ready.then(() => settled, () => settled);
 		return ready;
 	}
 

--- a/sources/JetAppBase.ts
+++ b/sources/JetAppBase.ts
@@ -150,6 +150,7 @@ export class JetAppBase extends JetBase implements IJetView {
 		}
 
 		return this.getSubView().refresh().then(view => {
+			// skip the route echo if the app was destroyed while the refresh was in flight
 			if (this._container){
 				this.callEvent("app:route", [this.getUrl()]);
 			}
@@ -367,7 +368,8 @@ export class JetAppBase extends JetBase implements IJetView {
 			.then(() => this.createFromURL(segment.current()))
 			.then(view => view.render(root, segment))
 			.then(base => {
-				// app may have been destroyed while the view was rendering
+				// app may have been destroyed mid-render: skip so a dead app can't
+				// rewrite the hash / push history via router.set()
 				if (this._container){
 					this.$router.set(segment.route.path, { silent:true });
 					this.callEvent("app:route", [this.getUrl()]);
@@ -375,13 +377,13 @@ export class JetAppBase extends JetBase implements IJetView {
 				return base;
 			});
 
-		// swallow benign navigation aborts on THIS render's promise directly, so an
-		// overlapping/blocked navigation can never leak an unhandled rejection while an
-		// earlier render is still parked (real errors are rethrown so they stay observable)
+		// attach the benign-abort handler to THIS render's promise directly: on the queued
+		// this.ready chain it would not run until an earlier parked render settled, leaving
+		// an overlapping rejection unhandled in the meantime (real errors are rethrown)
 		const settled = ready.catch(e => {
 			if (!(e instanceof NavigationBlocked)) throw e;
 		});
-		// keep the public ready promise progressing across renders (never sticks on abort)
+		// two-arg then so a prior render's failure can't leave the public ready chain stuck rejected
 		this.ready = this.ready.then(() => settled, () => settled);
 		return ready;
 	}

--- a/sources/JetAppBase.ts
+++ b/sources/JetAppBase.ts
@@ -24,6 +24,7 @@ export class JetAppBase extends JetBase implements IJetView {
 	private $router: IJetRouter;
 	private _services: { [name: string]: any };
 	private _subSegment: IRoute;
+	private _destroyed: boolean;
 
 	constructor(config?: any) {
 		const webix = (config || {}).webix || (window as any).webix;
@@ -59,6 +60,8 @@ export class JetAppBase extends JetBase implements IJetView {
 		this._services[name] = handler;
 	}
 	destructor(){
+		if (this._destroyed) return;
+		this._destroyed = true;
 		this.getSubView().destructor();
 		super.destructor();
 	}

--- a/sources/JetView.ts
+++ b/sources/JetView.ts
@@ -4,6 +4,7 @@ import {
 	IBaseConfig, IBaseView, IJetApp, IJetURL,
 	IJetView, IJetViewFactory, ISubView, IUIConfig, IRoute, IJetUrlTarget } from "./interfaces";
 import { Route } from "./Route";
+import { NavigationBlocked } from "./errors";
 
 
 export class JetView extends JetBase{
@@ -28,7 +29,9 @@ export class JetView extends JetBase{
 		const jetview = this.app.createView(ui);
 		this._children.push(jetview);
 
-		jetview.render(container, this._segment, this);
+		jetview.render(container, this._segment, this).catch(e => {
+			if (!(e instanceof NavigationBlocked)) throw e;
+		});
 
 		if (typeof ui !== "object" || (ui instanceof JetBase)){
 			// raw webix UI
@@ -187,6 +190,11 @@ export class JetView extends JetBase{
 	}
 
 	protected _render_final(config:any, url:IRoute):Promise<any>{
+		// view already destroyed while rendering was in flight
+		if (!this.app || !this._container){
+			return Promise.resolve(this.getRoot());
+		}
+
 		// get previous view in the same slot
 		let slot:ISubView = null;
 		let container:string|HTMLElement|IBaseView = null;
@@ -203,9 +211,9 @@ export class JetView extends JetBase{
 			container = this._container as HTMLElement;
 		}
 
-		// view already destroyed
-		if (!this.app || !container){
-			return Promise.reject(null);
+		// slot widget already destroyed
+		if (!container){
+			return Promise.resolve(this.getRoot());
 		}
 
 		let response:Promise<any>;

--- a/sources/JetView.ts
+++ b/sources/JetView.ts
@@ -172,6 +172,12 @@ export class JetView extends JetBase{
 		root = root || document.body;
 		const _container = (typeof root === "string") ? this.webix.toNode(root) : root;
 
+		// a string container id that does not resolve is a genuine mistake -> surface it
+		// (do not confuse with a destroyed view, where _container and app are nulled together)
+		if (!_container){
+			return Promise.reject(new Error("Webix Jet: container not found: " + root));
+		}
+
 		if (this._container !== _container) {
 			this._container = _container;
 			return this._render(url);

--- a/sources/JetView.ts
+++ b/sources/JetView.ts
@@ -29,6 +29,8 @@ export class JetView extends JetBase{
 		const jetview = this.app.createView(ui);
 		this._children.push(jetview);
 
+		// fire-and-forget render: swallow a benign navigation abort so it can't surface
+		// as an unhandled rejection (real errors still throw)
 		jetview.render(container, this._segment, this).catch(e => {
 			if (!(e instanceof NavigationBlocked)) throw e;
 		});
@@ -196,7 +198,8 @@ export class JetView extends JetBase{
 	}
 
 	protected _render_final(config:any, url:IRoute):Promise<any>{
-		// view already destroyed while rendering was in flight
+		// view/app torn down mid-render: resolve as a silent no-op instead of rejecting,
+		// so an in-flight render landing after destruction can't surface an uncaught error
 		if (!this.app || !this._container){
 			return Promise.resolve(this.getRoot());
 		}
@@ -217,7 +220,7 @@ export class JetView extends JetBase{
 			container = this._container as HTMLElement;
 		}
 
-		// slot widget already destroyed
+		// widget was destroyed under us (e.g. a jetapp widget torn down mid-render) -> same silent no-op
 		if (!container){
 			return Promise.resolve(this.getRoot());
 		}

--- a/sources/patch.ts
+++ b/sources/patch.ts
@@ -91,6 +91,8 @@ export default function patch(w: any){
 				this.$app.render({ id });
 			});
 		},
+		// tear down the embedded app with the widget so it can't outlive its host;
+		// nulling its _container also stops any in-flight render from touching a dead app
 		destructor(){
 			(w.ui as any).proxy.prototype.destructor.call(this);
 			if (this.$app) this.$app.destructor();

--- a/sources/patch.ts
+++ b/sources/patch.ts
@@ -90,6 +90,10 @@ export default function patch(w: any){
 				this.callEvent("onInit", [this.$app]);
 				this.$app.render({ id });
 			});
+		},
+		destructor(){
+			(w.ui as any).proxy.prototype.destructor.call(this);
+			if (this.$app) this.$app.destructor();
 		}
 	}, (w.ui as any).proxy, w.EventSystem);
 }

--- a/tests/destroy_mid_render.js
+++ b/tests/destroy_mid_render.js
@@ -37,6 +37,38 @@ describe("Destroy mid-render", () => {
         expect(unhandled.length).to.equal(0);
     });
 
+    // a blocked navigation that rejects while an earlier async render is
+    // still parked must not leak — its handler has to be attached to `ready` directly, not
+    // to the queued `this.ready.then(...)` chain (which only runs after the parked one settles).
+    it("does not leak a benign rejection when a blocked navigation overlaps a parked render", async () => {
+        let release;
+        const gate = new Promise(r => { release = r; });
+
+        class Table extends jet.JetView {
+            config(){ return gate.then(() => ({ template:"t" })); }
+        }
+        app = new jet.JetApp({ router: jet.EmptyRouter, start:"/Table",
+            views:{ Table, secret:{ template:"secret" } } });
+        app.attachEvent("app:guard", url => url.indexOf("secret") === -1);
+
+        const unhandled = [];
+        const onRej = e => { unhandled.push(e.reason); e.preventDefault(); };
+        window.addEventListener("unhandledrejection", onRej);
+
+        app.render("sandbox");   // ready #1 parked on the gate
+        app.show("/secret");     // ready #2 blocked -> rejects this turn, intentionally uncaught
+
+        // keep ready #1 parked across a task boundary: with the old code ready #2's handler
+        // is queued behind it, so ready #2 is unhandled at the microtask checkpoint here
+        await new Promise(r => setTimeout(r, 50));
+        window.removeEventListener("unhandledrejection", onRej);
+
+        // pre-fix: ready #2 has no handler yet (queued behind the parked ready #1) -> unhandled
+        expect(unhandled.length).to.equal(0);
+
+        release();   // let the parked render settle before teardown
+    });
+
     // destroying a jetapp widget must tear down its app (shared destructor),
     // so the render continuation does not run router.set()/app:route on a dead app.
     it("does not touch the router after a jetapp widget is destroyed mid-render", async () => {

--- a/tests/destroy_mid_render.js
+++ b/tests/destroy_mid_render.js
@@ -1,0 +1,40 @@
+describe("Destroy mid-render", () => {
+    let app;
+
+    afterEach(function(){
+        try { app.destructor(); } catch(e){}
+    });
+
+    // Repro of the reported bug: a jetapp widget (e.g. Webix Query) whose
+    // initial fire-and-forget render (patch.ts $app.render({id})) is still in flight
+    // when the widget is destroyed -> _render_final lands on the destroyed body cell.
+    it("silently no-ops when a jetapp widget is destroyed mid-render (widget.destructor())", async () => {
+        let release;
+        const gate = new Promise(r => { release = r; });
+
+        class Slow extends jet.JetView {
+            config(){ return gate.then(() => ({ template:"q" })); }
+        }
+        class MiniApp extends jet.JetApp {
+            constructor(cfg){
+                super(Object.assign({ router: jet.EmptyRouter, start:"/Slow", views:{ Slow } }, cfg));
+            }
+        }
+        webix.protoUI({ name:"jet_miniapp", app: MiniApp }, webix.ui.jetapp);
+
+        const unhandled = [];
+        const onRej = e => { unhandled.push(e.reason); e.preventDefault(); };
+        window.addEventListener("unhandledrejection", onRej);
+
+        const ui = webix.ui({ view:"jet_miniapp", container:"sandbox" }); // $ready -> $app.render({id}), fire-and-forget
+        ui.destructor();   // destroy the widget while its initial render is in flight
+        release();         // config resolves -> _render_final on the destroyed slot
+
+        await new Promise(r => setTimeout(r, 50));
+        window.removeEventListener("unhandledrejection", onRej);
+
+        // pre-fix: "Uncaught (in promise) null" leaks from the fire-and-forget $app.render
+        expect(unhandled.length).to.equal(0);
+    });
+
+});

--- a/tests/destroy_mid_render.js
+++ b/tests/destroy_mid_render.js
@@ -37,4 +37,37 @@ describe("Destroy mid-render", () => {
         expect(unhandled.length).to.equal(0);
     });
 
+    // destroying a jetapp widget must tear down its app (shared destructor),
+    // so the render continuation does not run router.set()/app:route on a dead app.
+    it("does not touch the router after a jetapp widget is destroyed mid-render", async () => {
+        let release;
+        const gate = new Promise(r => { release = r; });
+
+        class Slow extends jet.JetView {
+            config(){ return gate.then(() => ({ template:"q" })); }
+        }
+        class MiniApp extends jet.JetApp {
+            constructor(cfg){
+                super(Object.assign({ router: jet.EmptyRouter, start:"/Slow", views:{ Slow } }, cfg));
+            }
+        }
+        webix.protoUI({ name:"jet_miniapp2", app: MiniApp }, webix.ui.jetapp);
+
+        const ui = webix.ui({ view:"jet_miniapp2", container:"sandbox" });
+        app = ui.$app;   // let afterEach clean up
+
+        let routeAfterDestroy = 0;
+        let destroyed = false;
+        ui.$app.attachEvent("app:route", () => { if (destroyed) routeAfterDestroy++; });
+
+        destroyed = true;
+        ui.destructor();   // shared destructor -> $app.destructor() -> app._container nulled
+        release();         // config resolves -> render continuation runs on a dead app
+
+        await new Promise(r => setTimeout(r, 50));
+
+        // pre-fix (no shared destructor): app still alive -> continuation fires app:route
+        expect(routeAfterDestroy).to.equal(0);
+    });
+
 });

--- a/tests/destroy_mid_render.js
+++ b/tests/destroy_mid_render.js
@@ -102,4 +102,18 @@ describe("Destroy mid-render", () => {
         expect(routeAfterDestroy).to.equal(0);
     });
 
+    // an unknown string container id must surface as an explicit rejection,
+    // not silently resolve to nothing.
+    it("rejects with an explicit error when render() gets an unknown container id", async () => {
+        app = new jet.JetApp({ router: jet.EmptyRouter, start:"/x", views:{ x:{ template:"x" } } });
+
+        const pending = app.render("no-such-container-id");
+        app.ready.catch(() => {});   // the error mirrors onto the public ready chain; keep the harness quiet
+
+        let err = null;
+        await pending.catch(e => { err = e; });
+
+        expect(err instanceof Error).to.equal(true);
+    });
+
 });

--- a/tests/destroy_mid_render.js
+++ b/tests/destroy_mid_render.js
@@ -38,7 +38,7 @@ describe("Destroy mid-render", () => {
     });
 
     // a blocked navigation that rejects while an earlier async render is
-    // still parked must not leak — its handler has to be attached to `ready` directly, not
+    // still parked must not leak - its handler has to be attached to `ready` directly, not
     // to the queued `this.ready.then(...)` chain (which only runs after the parked one settles).
     it("does not leak a benign rejection when a blocked navigation overlaps a parked render", async () => {
         let release;

--- a/tests/index.html
+++ b/tests/index.html
@@ -42,7 +42,8 @@
       <script src="./app_in_app.js"></script>
       <script src="./jetappui.js"></script>
       <script src="./url.js"></script>
-      
+      <script src="./destroy_mid_render.js"></script>
+
       <script>
         mocha.run()
       </script>


### PR DESCRIPTION
the issue: at runtime, query and other jet-based widgets throw unhandled promise rejected(null) errors with no stack trace. not fatal, but unnecessarily litter the error log 

the cause - promise rejection with null in render when during render the app was destroyed
this may happen during navigation and destruction of views, but it's hard to reproduce when you want it just by interacting with the UI

the minimalist reproduction of the issue: https://snippet.webix.com/kaxhdkk7

- rejection was replaced with resolving
- the code that is dependent on resolving but must not run if the app was destroyed has checks for (this._container)
- additional and debatable (not related to this issue, but added as potentially useful) - .catch() guards for ready and render() in ui() 

the PR is into 2.2 since this seems to be the branch that is used to publish betas for the Jet widgets